### PR TITLE
Add back-tick to defaults for tsx and jsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,20 @@
                     "`"
                 ]
             },
+            "[typescriptreact]": {
+                "togglequotes.chars": [
+                    "\"",
+                    "'",
+                    "`"
+                ]
+            },
+            "[javascriptreact]": {
+                "togglequotes.chars": [
+                    "\"",
+                    "'",
+                    "`"
+                ]
+            },
             "[markdown]": {
                 "togglequotes.chars": [
                     "\"",


### PR DESCRIPTION
This change adds the back-type quote type (template literal) to React source files (JSX and TSX), which are just JavaScript and TypeScript files with HTML literals.