### PR TITLE
added support for backticks in svelte files

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,13 @@
                     "`"
                 ]
             },
+            "[svelte]": {
+                "togglequotes.chars": [
+                    "\"",
+                    "'",
+                    "`"
+                ]
+            },
             "[markdown]": {
                 "togglequotes.chars": [
                     "\"",


### PR DESCRIPTION
Easy enough. Thanks for the help!

I tested by copying the fork into 

`%USERPROFILE%\.vscode\extensions\britesnow.vscode-toggle-quotes-0.3.4`

Seems to have done the trick.