### PR TITLE
package.json: run automatically in remote dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "activationEvents": [
         "onCommand:editor.togglequotes"
     ],
+    "extensionKind": [
+      "ui",
+      "workspace"
+    ],
     "main": "./out/src/extension",
     "icon": "icon.png",
     "contributes": {


### PR DESCRIPTION
If you open VSCode in a remote dev environment, Toggle Quotes will be turned off:

<img width=400 src="https://user-images.githubusercontent.com/3344958/129690369-95ea9576-9e62-4f95-a1a6-a13f27044edf.png" />


There's more explanation [here](https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location), but the jist of it is that we can tell VSCode that Toggle Quotes never accesses any files or ports, so it can run locally instead of requiring you to install it on the server. This means when you connect to another server, it will be enabled by default.

You can test this out by:
1. clicking code > codespaces > new codespace
<img width=400 src="https://user-images.githubusercontent.com/3344958/129691033-faa2bb70-704b-481c-99ec-add2a9dff7bc.png" />

2. clicking "connect with vscode" and following the prompts
3. looking at extensions. Toggle Quotes should be disabled:

<img width=400 src="https://user-images.githubusercontent.com/3344958/129691143-679fae7c-b319-4276-b2f0-b7f8db0a7ef0.png" />

4. setting an override in your settings:
```json
  "remote.extensionKind": {
    "BriteSnow.vscode-toggle-quotes": ["ui", "workspace"]
  }
```
5. reload the window
6. now it's enabled!
<img width=400 src="https://user-images.githubusercontent.com/3344958/129691338-8aaaea5d-5345-4b47-b6e6-a4d9e5821226.png" />

Adding this because I've done a similar thing in my own extensions, https://marketplace.visualstudio.com/items?itemName=bmalehorn.vimspired and https://marketplace.visualstudio.com/items?itemName=bmalehorn.print-it.


