### PR TITLE
chore: add astro backtick support

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,13 @@
                     "`"
                 ]
             },
+            "[astro]": {
+                "togglequotes.chars": [
+                    "\"",
+                    "'",
+                    "`"
+                ]
+            },
             "[markdown]": {
                 "togglequotes.chars": [
                     "\"",


### PR DESCRIPTION
Adds backtick support for `*.astro` files.

In the meantime if someone finds this PR you can update your personal `settings.json` with the following key value pair.

```json
  "[astro]": {
    "togglequotes.chars": ["\"","'","`"]
  },
```